### PR TITLE
Create temp data directory before writing to it

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,7 +1,7 @@
 import joplin from 'api'
 import { v4 as uuidv4 } from 'uuid'
 import { tmpdir } from 'os'
-import { sep } from 'path'
+import { sep, dirname, join } from 'path'
 const fs = joplin.require('fs-extra')
 
 const Config = {
@@ -30,9 +30,13 @@ export function clearDiskCache(): void {
 
 async function writeJsonFile(name: string, data: string, filePath: string = null): Promise<string> {
     if (!filePath) {
-        filePath = `${Config.TempFolder}${name}.json`
+        filePath = join(Config.TempFolder, `${name}.json`)
     }
     filePath += buildTitle(data)
+
+    // Ensure the directory exists
+    await fs.mkdir(dirname(filePath), { recursive: true })
+
     await fs.writeFile(filePath, data)
     return filePath
 }


### PR DESCRIPTION
Hi, thanks for your work on this!

A user raised this issue on [the forum post](https://discourse.joplinapp.org/t/plugin-support-excalidraw-in-joplin/27686/28).
<img width="821" alt="image" src="https://github.com/user-attachments/assets/ab482326-68b4-4884-81e5-9f1ad3c24f2b">

The problem was that when you restart the computer, the tmp data folder is cleared, and the directory needs to be recreated.
The change I'm submitting makes the directory where the tmp data is to be written if it doesn't exist before writing the data.
